### PR TITLE
Gene probability

### DIFF
--- a/src/main/java/com/progressengine/geneinference/controller/BreedController.java
+++ b/src/main/java/com/progressengine/geneinference/controller/BreedController.java
@@ -20,7 +20,7 @@ public class BreedController {
     private final RelationshipService relationshipService;
     private final InferenceEngine inferenceEngine;
 
-    public BreedController(SheepService sheepService, RelationshipService relationshipService, @Qualifier("ensemble") InferenceEngine inferenceEngine) {
+    public BreedController(SheepService sheepService, RelationshipService relationshipService, @Qualifier("loopy") InferenceEngine inferenceEngine) {
         this.sheepService = sheepService;
         this.relationshipService = relationshipService;
         this.inferenceEngine = inferenceEngine;

--- a/src/main/java/com/progressengine/geneinference/service/EnsembleInference.java
+++ b/src/main/java/com/progressengine/geneinference/service/EnsembleInference.java
@@ -10,7 +10,7 @@ import java.util.*;
 
 @Service("ensemble")
 public class EnsembleInference extends BaseInferenceEngine {
-    private final RelationshipService relationshipService;
+    protected final RelationshipService relationshipService;
 
     public EnsembleInference(RelationshipService relationshipService) {
         this.relationshipService = relationshipService;

--- a/src/main/java/com/progressengine/geneinference/service/LoopyInference.java
+++ b/src/main/java/com/progressengine/geneinference/service/LoopyInference.java
@@ -1,0 +1,82 @@
+package com.progressengine.geneinference.service;
+
+import com.progressengine.geneinference.model.GradePair;
+import com.progressengine.geneinference.model.Relationship;
+import com.progressengine.geneinference.model.Sheep;
+import com.progressengine.geneinference.model.enums.Grade;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service("loopy")
+public class LoopyInference extends EnsembleInference {
+
+    public LoopyInference(RelationshipService relationshipService) {
+        super(relationshipService);
+    }
+
+    @Override
+    public void updateMarginalProbabilities(Relationship relationship) {
+        Sheep parent1 = relationship.getParent1();
+        Sheep parent2 = relationship.getParent2();
+
+        // List of relationships for each parent
+        List<Relationship> parent1Relationships = relationshipService.findRelationshipsByParent(parent1);
+        List<Relationship> parent2Relationships = relationshipService.findRelationshipsByParent(parent2);
+
+        // loopy belief propagation to get new marginals
+        Map<Grade, Double> parent1NewMarginalProbabilities = loopMarginalProbability(parent1, parent1Relationships, parent2Relationships, relationship, parent2);
+        Map<Grade, Double> parent2NewMarginalProbabilities = loopMarginalProbability(parent2, parent2Relationships, parent1Relationships, relationship, parent1);
+
+
+        parent1.setHiddenDistribution(parent1NewMarginalProbabilities);
+        parent2.setHiddenDistribution(parent2NewMarginalProbabilities);
+    }
+
+    // TODO - parents forget their own previous relationships
+    private Map<Grade, Double> loopMarginalProbability(Sheep parent, List<Relationship> relationships, List<Relationship> otherParentsRelationships, Relationship currentRelationship, Sheep otherParent) {
+        // calculate the message to the current relationship
+        Map<Grade, Double> messageToRelationship = otherParent.getPriorDistribution() != null && !otherParent.getPriorDistribution().isEmpty() ? new EnumMap<>(otherParent.getPriorDistribution()) : SheepService.createUniformDistribution();
+        for (Relationship relationship : otherParentsRelationships) {
+            if (!relationship.getId().equals(currentRelationship.getId())) {
+                Sheep secondaryParent = relationship.getParent1().getId().equals(otherParent.getId()) ? relationship.getParent2() : relationship.getParent1();
+                boolean firstParent = relationship.getParent1().getId().equals(secondaryParent.getId()); // whether the secondary parent is the first or not
+                productOfExperts(messageToRelationship, halfJointMarginal(relationship, secondaryParent.getHiddenDistribution(), firstParent));
+            }
+        }
+
+        Map<Grade, Double> newMarginal = parent.getPriorDistribution() != null && !parent.getPriorDistribution().isEmpty() ? new EnumMap<>(parent.getPriorDistribution()) : SheepService.createUniformDistribution();
+        productOfExperts(newMarginal, halfJointMarginal(currentRelationship, messageToRelationship, currentRelationship.getParent1().getId().equals(otherParent.getId())));
+
+        // combine the message from this relationship with the other relationships for this parent
+        for (Relationship relationship : relationships) {
+            if (!relationship.getId().equals(currentRelationship.getId())) {
+                Sheep secondaryParent = relationship.getParent1().getId().equals(parent.getId()) ? relationship.getParent2() : relationship.getParent1();
+                boolean firstParent = relationship.getParent1().getId().equals(secondaryParent.getId()); // whether the secondary parent is the first or not
+                productOfExperts(newMarginal, halfJointMarginal(relationship, secondaryParent.getHiddenDistribution(), firstParent));
+            }
+        }
+
+        return newMarginal;
+    }
+
+    // Marginalizes the joint distribution using the specified weight distribution and which parent it relates to in the relationship, the score parent
+    private Map<Grade, Double> halfJointMarginal(Relationship relationship, Map<Grade, Double> gradeDistribution, boolean firstParent) {
+        Map<Grade, Double> newHalfMarginal = new EnumMap<>(Grade.class);
+        Map<GradePair, Double> jointDistribution = relationship.getHiddenPairsDistribution();
+
+        for (Map.Entry<GradePair, Double> entry : jointDistribution.entrySet()) {
+            GradePair pair = entry.getKey();
+            double probability = entry.getValue();
+            Grade scoreGrade = firstParent ? pair.getFirst() : pair.getSecond();
+            Grade targetGrade = firstParent ? pair.getSecond() : pair.getFirst();
+
+            newHalfMarginal.merge(targetGrade, probability * gradeDistribution.get(scoreGrade), Double::sum);
+        }
+        normalizeScores(newHalfMarginal);
+
+        return newHalfMarginal;
+    }
+}

--- a/src/main/java/com/progressengine/geneinference/service/LoopyInference.java
+++ b/src/main/java/com/progressengine/geneinference/service/LoopyInference.java
@@ -35,7 +35,7 @@ public class LoopyInference extends EnsembleInference {
         parent2.setHiddenDistribution(parent2NewMarginalProbabilities);
     }
 
-    // TODO - parents forget their own previous relationships
+    // Uses the principal of loopy belief propagation to pass messages from immediate partners to the relationship in question
     private Map<Grade, Double> loopMarginalProbability(Sheep parent, List<Relationship> relationships, List<Relationship> otherParentsRelationships, Relationship currentRelationship, Sheep otherParent) {
         // calculate the message to the current relationship
         Map<Grade, Double> messageToRelationship = otherParent.getPriorDistribution() != null && !otherParent.getPriorDistribution().isEmpty() ? new EnumMap<>(otherParent.getPriorDistribution()) : SheepService.createUniformDistribution();
@@ -43,6 +43,7 @@ public class LoopyInference extends EnsembleInference {
             if (!relationship.getId().equals(currentRelationship.getId())) {
                 Sheep secondaryParent = relationship.getParent1().getId().equals(otherParent.getId()) ? relationship.getParent2() : relationship.getParent1();
                 boolean firstParent = relationship.getParent1().getId().equals(secondaryParent.getId()); // whether the secondary parent is the first or not
+                // the message to the current relationship is the product of the messages from all other relationships
                 productOfExperts(messageToRelationship, halfJointMarginal(relationship, secondaryParent.getHiddenDistribution(), firstParent));
             }
         }

--- a/src/main/java/com/progressengine/geneinference/service/SheepService.java
+++ b/src/main/java/com/progressengine/geneinference/service/SheepService.java
@@ -64,6 +64,7 @@ public class SheepService {
             throw new IllegalArgumentException("hiddenDistribution must include all grades");
         }
         sheep.setHiddenDistribution(dto.getHiddenDistribution());
+        sheep.setPriorDistribution(new EnumMap<>(dto.getHiddenDistribution()));
 
         if (dto.getParentRelationshipId() != null) {
             Relationship relationship = relationshipRepository.findById(dto.getParentRelationshipId())

--- a/src/test/java/com/progressengine/geneinference/service/InferenceEngineTest.java
+++ b/src/test/java/com/progressengine/geneinference/service/InferenceEngineTest.java
@@ -197,6 +197,12 @@ public abstract class InferenceEngineTest {
         Sheep sheep = new Sheep();
         sheep.setPhenotype(phenotype);
         sheep.setHiddenDistribution(hiddenDistribution);
+        sheep.setPriorDistribution(SheepService.createUniformDistribution());
+        return sheep;
+    }
+    protected Sheep createTestSheep(Grade phenotype, Map<Grade, Double> hiddenDistribution, int sheepId) {
+        Sheep sheep = createTestSheep(phenotype, hiddenDistribution);
+        sheep.setId(sheepId);
         return sheep;
     }
 
@@ -205,6 +211,12 @@ public abstract class InferenceEngineTest {
         relationship.setParent1(parent1);
         relationship.setParent2(parent2);
         relationship.setOffspringPhenotypeFrequency(offspringPhenotypeFrequency);
+        return relationship;
+    }
+
+    protected Relationship createTestRelationship(Sheep parent1, Sheep parent2, Map<Grade, Integer> offspringPhenotypeFrequency, int relationshipId) {
+        Relationship relationship = createTestRelationship(parent1, parent2, offspringPhenotypeFrequency);
+        relationship.setId(relationshipId);
         return relationship;
     }
 }

--- a/src/test/java/com/progressengine/geneinference/service/LoopyInferenceTest.java
+++ b/src/test/java/com/progressengine/geneinference/service/LoopyInferenceTest.java
@@ -13,30 +13,30 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class EnsembleInferenceTest extends InferenceEngineTest {
-    @Mock
-    protected RelationshipService relationshipService;
-
+public class LoopyInferenceTest extends EnsembleInferenceTest {
     @BeforeEach
     public void setUp() {
-        inferenceEngine = new EnsembleInference(relationshipService);
+        inferenceEngine = new LoopyInference(relationshipService);
     }
 
     @Override
     @Test
     void testUpdateMarginalDistribution() {
         // Arrange
-        Sheep parent1 = createTestSheep(Grade.A, SheepService.createUniformDistribution());
+        Sheep parent1 = createTestSheep(Grade.A, SheepService.createUniformDistribution(), 1);
 
-        Sheep parent2 = createTestSheep(Grade.B, SheepService.createUniformDistribution());
+        Sheep parent2 = createTestSheep(Grade.B, SheepService.createUniformDistribution(), 2);
 
         Relationship relationship = createTestRelationship(parent1, parent2, Map.ofEntries(
                 Map.entry(Grade.C, 1)
-        ));
+        ), 1);
 
         inferenceEngine.findJointDistribution(relationship);
 
@@ -86,15 +86,15 @@ public class EnsembleInferenceTest extends InferenceEngineTest {
     @Test
     void testInferChildDistributionChild1() {
         // Arrange
-        Sheep parent1 = createTestSheep(Grade.B, SheepService.createUniformDistribution());
+        Sheep parent1 = createTestSheep(Grade.B, SheepService.createUniformDistribution(), 1);
 
-        Sheep parent2 = createTestSheep(Grade.B, SheepService.createUniformDistribution());
+        Sheep parent2 = createTestSheep(Grade.B, SheepService.createUniformDistribution(), 2);
 
         Relationship relationship = createTestRelationship(parent1, parent2, Map.ofEntries(
                 Map.entry(Grade.B, 53),
                 Map.entry(Grade.C, 24),
                 Map.entry(Grade.D, 23)
-        ));
+        ), 1);
 
         Sheep child = createTestSheep(Grade.D, SheepService.createUniformDistribution());
 
@@ -127,13 +127,13 @@ public class EnsembleInferenceTest extends InferenceEngineTest {
     @Test
     void testInferChildDistributionChild2() {
         // Arrange
-        Sheep parent1 = createTestSheep(Grade.A, SheepService.createUniformDistribution());
+        Sheep parent1 = createTestSheep(Grade.A, SheepService.createUniformDistribution(), 1);
 
-        Sheep parent2 = createTestSheep(Grade.B, SheepService.createUniformDistribution());
+        Sheep parent2 = createTestSheep(Grade.B, SheepService.createUniformDistribution(), 2);
 
         Relationship relationship = createTestRelationship(parent1, parent2, Map.ofEntries(
                 Map.entry(Grade.C, 1)
-        ));
+        ), 1);
 
         Sheep child = createTestSheep(Grade.C, SheepService.createUniformDistribution());
 


### PR DESCRIPTION
Added a new inference engine implementation that is based on loopy belief propagation and message passing. This version does not iteratively flow through the relationship graph but instead, stops at the immediate partners of the parents that need to be updated. This allows a balance between precision and performance cost.

other changes:
- Test cases for the loopy engine were added
- Adding new sheep now correctly sets their prior distribution